### PR TITLE
Fix the service

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 name := visitor
-version := 0.5.0
+version := 0.6.0
 pkgname := $(name)-$(version)
 
 all: linux windows

--- a/README.md
+++ b/README.md
@@ -31,8 +31,8 @@ reported on original cluster address.
 The visitor stores the last visit info at `visitor.json` in the directory
 where the server is started.
 
-When running as a Linux service, the visitor.json file is located in
-/run/visitor.
+When running as a Linux service, the `visitor.json` file is located in
+`/usr/lib/visitor`.
 
 To clear the visitor state, delete the file.
 

--- a/visitor.service
+++ b/visitor.service
@@ -9,9 +9,9 @@ After=network.target
 Type=notify
 Restart=always
 User=visitor
+StateDirectory=visitor
+WorkingDirectory=/var/lib//visitor
 ExecStart=/usr/bin/visitor
-WorkingDirectory=/run/visitor
-RuntimeDirectory=visitor
 
 [Install]
 WantedBy=multi-user.target

--- a/visitor.service
+++ b/visitor.service
@@ -3,7 +3,7 @@
 
 [Unit]
 Description=visitor service
-After=network.target
+After=cloud-final.service
 
 [Service]
 Type=notify

--- a/visitor.spec
+++ b/visitor.spec
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 Name: visitor
-Version: 0.5.0
+Version: 0.6.0
 Release: 1%{?dist}
 Summary: Disaster recovery demo
 


### PR DESCRIPTION
- Store data in /var/lib/visitor so data is persisted after reboot
- Start after cloud-final.service so we can see the mounted config volume